### PR TITLE
Add boolean `wrap` value to result of measure function

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ If mode is `"pre"` and `width` is specified, it will clip the characters to the 
 
 #### `lines = wordwrap.lines(text[, opt])`
 
-Takes the same parameters as the above method, but returns a list of "lines" objects for manual text layout/rendering. A "line" is typically an object with `{ start, end }` indices that can be used with `text.substring(start, end)`. The "line" is the return value from the `measure` function, so it may also include application-specific data (i.e. to avoid re-computing line widths).
+Takes the same parameters as the above method, but returns a list of "lines" objects for manual text layout/rendering. A "line" is typically an object with `{ start, end, wrap }` indices that can be used with `text.substring(start, end)` and the boolean `wrap` that is true for lines of text that were long enough to wrap. The "line" is the return value from the `measure` function, so it may also include application-specific data (i.e. to avoid re-computing line widths).
 
 ## measure
 
 To layout glyphs in 2D space, you typically will need to measure the width of each glyph (and its x-advance, kerning, etc) to determine the maximum number of glyphs that can fit within a specified *available width*. 
 
-You can pass a custom `measure` function which takes the text being wrapped, the `start` (inclusive) and `end` (exclusive) indices into the string, and the desired `width`. The return value should be an object with `{ start, end }` indices, representing the actual glyphs that can be rendered within those bounds. 
+You can pass a custom `measure` function which takes the text being wrapped, the `start` (inclusive) and `end` (exclusive) indices into the string, and the desired `width`. The return value should be an object with `{ start, end, wrap }` indices, representing the actual glyphs that can be rendered within those bounds. `wrap` is a boolean representing whether the line was forced to wrap.
 
 For example, a Canvas2D implementation that uses monospace fonts might look like this:
 
@@ -90,7 +90,8 @@ function createMetrics(context, font) {
         var glyphs = Math.min(end-start, availableGlyphs, totalGlyphs)
         return {
             start: start,
-            end: start+glyphs
+            end: start+glyphs,
+            wrap: totalGlyphs > glyphs*charWidth
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ function greedy(measure, text, start, end, width, mode) {
         }
         if (lineEnd >= start) {
             var result = measure(text, start, lineEnd, testWidth)
+            result.wrap = measured.wrap;
             lines.push(result)
         }
         start = nextStart
@@ -119,9 +120,11 @@ function greedy(measure, text, start, end, width, mode) {
 
 //determines the visible number of glyphs within a given width
 function monospace(text, start, end, width) {
-    var glyphs = Math.min(width, end-start)
+    var length = end-start;
+    var glyphs = Math.min(width, length)
     return {
         start: start,
-        end: start+glyphs
+        end: start+glyphs,
+        wrap: length > width
     }
 }

--- a/test.js
+++ b/test.js
@@ -49,8 +49,8 @@ test('wrap a sub-section', function(t) {
 test('custom compute function', function(t) {
     //a custom compute function that assumes pixel width instead of monospace char width
     var word = 'words'
-    t.deepEqual(compute2(word, 0, word.length, 4), { end: 0, start: 0, width: 0 }, 'test compute')
-    t.deepEqual(compute2(word, 0, word.length, 5), { end: 1, start: 0, width: 5 }, 'test compute')
+    t.deepEqual(compute2(word, 0, word.length, 4), { end: 0, start: 0, width: 0, wrap: true }, 'test compute')
+    t.deepEqual(compute2(word, 0, word.length, 5), { end: 1, start: 0, width: 5, wrap: true }, 'test compute')
 
     var text = 'some lines'
     t.equal(wrap(text, { width: 20, measure: compute2 }), 'some\nline\ns', 'cuts text with variable glyph width')
@@ -58,8 +58,22 @@ test('custom compute function', function(t) {
 })
 
 test('wraps text to a list of lines', function(t) {
-    var expected = [ { end: 9, start: 0 }, { end: 15, start: 10 } ]
+    var expected = [ { end: 9, start: 0, wrap: true }, { end: 15, start: 10, wrap: false } ]
     t.deepEqual(lines('the quick brown', { width: 10 }), expected, 'returns a list of substring indices')
+    t.end()
+})
+
+test('lines includes wrap boolean value', function(t) {
+    var expected1 = [ { end: 9, start: 0, wrap: true }, { end: 15, start: 10, wrap: false } ]
+    t.deepEqual(lines('the quick brown', { width: 10 }), expected1, 'returns a list of substring indices with correct wrap values')
+
+    var expected2 = [ { end: 9, start: 0, wrap: true }, { end: 15, start: 10, wrap: false }, { end: 25, start: 16, wrap: true }, { end: 34, start: 26, wrap: true }, { end: 43, start: 35, wrap: false } ]
+    t.deepEqual(lines('the quick brown\nfox jumps over the lazy dog', { width: 10 }), expected2, 'returns a list of substring indices with correct wrap values')
+
+    var text = 'some lines'
+    var expected3 = [ { end: 4, start: 0, width: 20, wrap: true }, { end: 9, start: 5, width: 20, wrap: true }, { end: 10, start: 9, width: 5, wrap: false } ]
+    t.deepEqual(lines(text, { width: 20, measure: compute2 }), expected3, 'wrap value from custom measure function')
+
     t.end()
 })
 
@@ -73,7 +87,8 @@ function compute2(text, start, end, width) {
     return {
         width: glyphs * pxWidth, //only used for unit test
         start: start,
-        end: start+glyphs
+        end: start+glyphs,
+        wrap: totalGlyphs > glyphs*pxWidth
     }
 }
 


### PR DESCRIPTION
- Useful for laying out justify-aligned text
- Added unit tests
- Updated documentation

See https://github.com/Jam3/layout-bmfont-text/pull/5