### PR TITLE
Respect non-breaking spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var newline = /\n/
 var newlineChar = '\n'
-var whitespace = /\s/
+var whitespace = /(?!\u00A0)\s/
 
 module.exports = function(text, opt) {
     var lines = module.exports.lines(text, opt)


### PR DESCRIPTION
Non-breaking spaces (HTML's `&nbsp;`, unicode character 160 / \u00A0 should not be considered whitespace.